### PR TITLE
Add support for LLVM MinGW

### DIFF
--- a/CMake/Platform/MinGW.cmake
+++ b/CMake/Platform/MinGW.cmake
@@ -11,7 +11,7 @@ function(Pro_ApplyPlatform TargetName)
             -w -ffunction-sections -fdata-sections -fbuiltin
             -fno-stack-protector -std=c++20 -fms-extensions
             $<$<CONFIG:Release>:-gcodeview>
-            $<$<CONFIG:Debug>:-fno-exceptions -fno-asynchronous-unwind-tables>
+            $<$<CONFIG:Debug>:-fno-asynchronous-unwind-tables>
     )
 
     set(TARGET_COMPILE_DEFS

--- a/CMake/Platform/MinGW.cmake
+++ b/CMake/Platform/MinGW.cmake
@@ -1,21 +1,23 @@
-if(!MSVC)
-    message(FATAL_ERROR "Prometheus only supports building with MSVC and MinGW with LLVM on Windows.")
+if(!MinGW OR NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    message(FATAL_ERROR "Prometheus only supports building with MSVC and LLVM MinGW on Windows.")
 endif()
 
-set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo,Release>:ProgramDatabase>")
-set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+add_compile_options("$<$<CONFIG:Debug,RelWithDebInfo,Release>:-gcodeview>")
+set(CMAKE_SHARED_LINKER_FLAGS "-shared-libgcc -rtlib=compiler-rt")
 set(CMAKE_SYSTEM_NAME Windows)
 
 function(Pro_ApplyPlatform TargetName)
     set(TARGET_COMPILE_OPTIONS
-            /W0 /Gy /Oi /GS- /std:c++20 /Zc:preprocessor /permissive-
-            $<$<CONFIG:Release>:/Zi>
-            $<$<CONFIG:Debug>:/EHa- /EHs- /EHc- /EHr->
+            -w -ffunction-sections -fdata-sections -fbuiltin
+            -fno-stack-protector -std=c++20 -fms-extensions
+            $<$<CONFIG:Release>:-gcodeview>
+            $<$<CONFIG:Debug>:-fno-exceptions -fno-asynchronous-unwind-tables>
     )
 
     set(TARGET_COMPILE_DEFS
-            _WINDOWS _WINSOCKAPI_ prometheus_EXPORTS NOGDI _USRDLL
+            _WINDOWS _WIN32 _WINSOCKAPI_ prometheus_EXPORTS NOGDI _USRDLL
             SPDLOG_FMT_EXTERNAL IMGUI_DEFINE_MATH_OPERATORS IMGUI_USE_WCHAR32
+            WINVER=0x0A00 _WIN32_WINNT=0x0A00
             $<$<CONFIG:Release>:WIN32_LEAN_AND_MEAN NDEBUG _CRT_SECURE_NO_WARNINGS>
     )
 
@@ -24,7 +26,7 @@ function(Pro_ApplyPlatform TargetName)
     )
 
     set(TARGET_LINK_OPTIONS
-            /DLL /DEBUG
+            -shared -Wl,--gc-sections
     )
 
     message("Configuring target: ${TargetName} with options:")

--- a/CMake/Platform/MinGW.cmake
+++ b/CMake/Platform/MinGW.cmake
@@ -11,7 +11,7 @@ function(Pro_ApplyPlatform TargetName)
             -w -ffunction-sections -fdata-sections -fbuiltin
             -fno-stack-protector -std=c++20 -fms-extensions
             $<$<CONFIG:Release>:-gcodeview>
-            $<$<CONFIG:Debug>:-fno-asynchronous-unwind-tables>
+            $<$<CONFIG:Debug>:-fignore-exceptions -fno-asynchronous-unwind-tables>
     )
 
     set(TARGET_COMPILE_DEFS

--- a/CMake/Platform/MinGW.cmake
+++ b/CMake/Platform/MinGW.cmake
@@ -3,7 +3,7 @@ if(!MinGW OR NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 add_compile_options("$<$<CONFIG:Debug,RelWithDebInfo,Release>:-gcodeview>")
-set(CMAKE_SHARED_LINKER_FLAGS "-shared-libgcc -rtlib=compiler-rt")
+set(CMAKE_SHARED_LINKER_FLAGS "-static-libgcc -static-libstdc++")
 set(CMAKE_SYSTEM_NAME Windows)
 
 function(Pro_ApplyPlatform TargetName)
@@ -17,7 +17,7 @@ function(Pro_ApplyPlatform TargetName)
     set(TARGET_COMPILE_DEFS
             _WINDOWS _WIN32 _WINSOCKAPI_ prometheus_EXPORTS NOGDI _USRDLL
             SPDLOG_FMT_EXTERNAL IMGUI_DEFINE_MATH_OPERATORS IMGUI_USE_WCHAR32
-            WINVER=0x0A00 _WIN32_WINNT=0x0A00
+            WINVER=0x0601 _WIN32_WINNT=0x0601
             $<$<CONFIG:Release>:WIN32_LEAN_AND_MEAN NDEBUG _CRT_SECURE_NO_WARNINGS>
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.31)
-include(CMake/Platform/${PRO_PLATFORM}.cmake)
 
 project(Prometheus
         DESCRIPTION "Research and Reverse-Engineering project of Overwatch!"
@@ -7,6 +6,7 @@ project(Prometheus
 
 include_directories(external)
 
+include(CMake/Platform/${PRO_PLATFORM}.cmake)
 include(CMake/Configure.cmake)
 include(CMake/Version.cmake)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -57,6 +57,53 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug"
       }
+    },
+    {
+      "hidden": true,
+      "name": "MinGW",
+      "generator": "Ninja",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/external/vcpkg/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_HOST_TRIPLET": "x64-mingw-static",
+        "VCPKG_TARGET_TRIPLET": "x64-mingw-static",
+        "PRO_PLATFORM": "MinGW"
+      },
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      },
+      "vendor": {
+        "jetbrains.com/clion": {
+          "toolchain": "MinGW"
+        },
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": [ "Windows" ]
+        }
+      },
+      "environment": {
+        "VCPKG_ROOT": "${sourceDir}/external/vcpkg",
+        "VCPKG_DEFAULT_TRIPLET": "x64-mingw-static",
+        "VCPKG_KEEP_ENV_VARS": "PATH"
+      }
+    },
+    {
+      "name": "Release-MinGW",
+      "displayName": "Release MinGW Build",
+      "description": "Build for LLVM MinGW x64 in Release mode",
+      "inherits": "MinGW",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "Debug-MinGW",
+      "displayName": "Debug MinGW Build",
+      "description": "Build for LLVM MinGW x64 in Debug mode",
+      "inherits": "MinGW",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
     }
   ]
 }

--- a/Prometheus-Core/CMakeLists.txt
+++ b/Prometheus-Core/CMakeLists.txt
@@ -160,7 +160,9 @@ Pro_SetOutput(Prometheus-Core ${DIR_BIN} ${DIR_LIB})
 
 # Dll Config
 set_target_properties(Prometheus-Core PROPERTIES OUTPUT_NAME "PrometheusCore")
-target_link_options(Prometheus-Core PRIVATE /ILK:${DIR_LIB}/Prometheus-Core.ilk)
+if(MSVC)
+    target_link_options(Prometheus-Core PRIVATE /ILK:${DIR_LIB}/Prometheus-Core.ilk)
+endif ()
 
 # Dependencies
 target_link_libraries(Prometheus-Generator PRIVATE Prometheus-Generation)
@@ -190,6 +192,8 @@ target_link_libraries(Prometheus-Core PRIVATE fmt::fmt-header-only)
 
 find_package(spdlog CONFIG REQUIRED)
 target_link_libraries(Prometheus-Core PRIVATE spdlog::spdlog_header_only)
+
+target_link_libraries(Prometheus-Core PRIVATE d3dcompiler dwmapi)
 #get_target_property(IMGUI_INCLUDE_DIRS imgui::imgui
 #        INTERFACE_INCLUDE_DIRECTORIES
 #)

--- a/Prometheus-Core/Logs/Detail.cpp
+++ b/Prometheus-Core/Logs/Detail.cpp
@@ -2,6 +2,8 @@
 
 #include "Detail.h"
 
+#include <spdlog/sinks/sink.h>
+
 #include "Common.h"
 #include "Patterner.h"
 #include "globals.h"

--- a/Prometheus-Core/Logs/Detail.h
+++ b/Prometheus-Core/Logs/Detail.h
@@ -28,6 +28,10 @@
     ILOG(logger, Nested, Critical, "********* Exception End *********");                \
     Logs::logger->Newline();
 
+struct _EXCEPTION_POINTERS;
+struct _CONTEXT;
+struct _EXCEPTION_RECORD;
+
 namespace Logs::Detail
 {
     enum LogLevel : int {

--- a/Prometheus-Core/Logs/Patterner.h
+++ b/Prometheus-Core/Logs/Patterner.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include <spdlog/spdlog.h>
+#include <spdlog/formatter.h>
+#include <spdlog/pattern_formatter.h>
 
 class logger_patterner final : public spdlog::formatter
 {

--- a/Prometheus-Core/StatescriptExpressionParser.h
+++ b/Prometheus-Core/StatescriptExpressionParser.h
@@ -541,7 +541,7 @@ public:
 			opcassert(cvd);
 			char result = _context.parser->_ss->vfptr->CVD_Satisfies_InterceptorArr(_context.parser->_ss, cvd, &value);
 
-			ImGui::Text("TVA-%d = interceptor([CVD-%d] %s) (Interceptor Res: %d)", new_context.tva_index, cv_index, value.get_value_str(), result);
+			ImGui::Text("TVA-%d = interceptor([CVD-%d] %s) (Interceptor Res: %d)", new_context.tva_index, cv_index, value.get_value_str().c_str(), result);
 
 			_context.parser->display_next(new_context, _context.opc_index + get_size());
 			return true;

--- a/Prometheus-Core/UI/window_manager/window_manager.cpp
+++ b/Prometheus-Core/UI/window_manager/window_manager.cpp
@@ -281,7 +281,8 @@ void window_manager::render() {
 }
 
 std::shared_ptr<window> window_manager::get_docked(window_type typ, window* from) {
-	if (from && !ImGui::IsKeyDown(ImGuiKey_ModCtrl)) {
+	// PARALIRA: I CHANGED THIS HERE TO A LLDB SUGGESTED VALUE, CHANGE IT TO SOMETHING ELSE IF NEEDED!
+	if (from && !ImGui::IsKeyDown(ImGuiKey_LeftCtrl)) {
 		for (auto& window : s_windows) {
 			auto dock_window = window->get_root_dock().lock();
 			if (dock_window) {

--- a/Prometheus-Core/UI/windows/CVD_Edit.h
+++ b/Prometheus-Core/UI/windows/CVD_Edit.h
@@ -62,7 +62,7 @@ class CVD_Edit : public window {
                         _out_type.value = parsed;
                     }
                     else if (_out_type.type == StatescriptPrimitive_Type::StatescriptPrimitive_FLT) {
-                        float value = _strtof_l(_value, nullptr, nullptr);
+                        float value = strtof(_value, nullptr);
                         if (errno == EINVAL) {
                             return;
                         }
@@ -71,14 +71,14 @@ class CVD_Edit : public window {
                 }
                 if (_out_type.type == StatescriptPrimitive_Type::StatescriptPrimitive_VEC3) {
                     if (ImGui::InputText("Value2", _value2, 256)) {
-                        float value = _strtof_l(_value2, nullptr, nullptr);
+                        float value = strtof(_value2, nullptr);
                         if (errno == EINVAL) {
                             return;
                         }
                         *(float*)((__int64)&_out_type.value + 4) = value;
                     }
                     if (ImGui::InputText("Value3", _value3, 256)) {
-                        float value = _strtof_l(_value3, nullptr, nullptr);
+                        float value = strtof(_value3, nullptr);
                         if (errno == EINVAL) {
                             return;
                         }

--- a/Prometheus-Core/UI/windows/CVD_Edit.h
+++ b/Prometheus-Core/UI/windows/CVD_Edit.h
@@ -62,7 +62,7 @@ class CVD_Edit : public window {
                         _out_type.value = parsed;
                     }
                     else if (_out_type.type == StatescriptPrimitive_Type::StatescriptPrimitive_FLT) {
-                        float value = strtof(_value, nullptr);
+                        float value = _strtof_l(_value, nullptr, nullptr);
                         if (errno == EINVAL) {
                             return;
                         }
@@ -71,14 +71,14 @@ class CVD_Edit : public window {
                 }
                 if (_out_type.type == StatescriptPrimitive_Type::StatescriptPrimitive_VEC3) {
                     if (ImGui::InputText("Value2", _value2, 256)) {
-                        float value = strtof(_value2, nullptr);
+                        float value = _strtof_l(_value2, nullptr, nullptr);
                         if (errno == EINVAL) {
                             return;
                         }
                         *(float*)((__int64)&_out_type.value + 4) = value;
                     }
                     if (ImGui::InputText("Value3", _value3, 256)) {
-                        float value = strtof(_value3, nullptr);
+                        float value = _strtof_l(_value3, nullptr, nullptr);
                         if (errno == EINVAL) {
                             return;
                         }

--- a/Prometheus-Core/UI/windows/bitconverter_calls.h
+++ b/Prometheus-Core/UI/windows/bitconverter_calls.h
@@ -58,7 +58,7 @@ class bitconverter_calls : public window {
 	}
 
 	inline void preStartInitialize() override {
-		MH_CreateHook((LPVOID)(globals::gameBase + 0x848720), flipBits_hook, (void**)&flipBits_orig);
+		MH_CreateHook((LPVOID)(globals::gameBase + 0x848720), (LPVOID)flipBits_hook, (void**)&flipBits_orig);
 		//MH_EnableHook((LPVOID)(globals::gameBase + 0x848720));
 	}
 	//inline void initialize() override {}

--- a/Prometheus-Core/UI/windows/ini_settings_window.h
+++ b/Prometheus-Core/UI/windows/ini_settings_window.h
@@ -105,7 +105,7 @@ class ini_settings_window : public window {
 				ImGui::Text("%s", ini->parsed_value.get());
 
 				ImGui::TableNextColumn();
-				ImGui::Text("%s", ini_type_to_string(ini->ini_type));
+				ImGui::Text("%s", ini_type_to_string(ini->ini_type).c_str());
 
 				ImGui::TableNextColumn();
 				switch (ini->ini_type) {

--- a/Prometheus-Core/UI/windows/jam_messagedetail_window.h
+++ b/Prometheus-Core/UI/windows/jam_messagedetail_window.h
@@ -81,7 +81,7 @@ public:
 		ImGui::Text("%s", item->name_str);
 
 		ImGui::TableNextColumn();
-		ImGui::Text("%s", get_type_str(item->message_type));
+		ImGui::Text("%s", get_type_str(item->message_type).c_str());
 
 		ImGui::TableNextColumn();
 		ImGui::Text("%x %d", item->offset, item->offset);

--- a/Prometheus-Core/UI/windows/jamprotocol_window.h
+++ b/Prometheus-Core/UI/windows/jamprotocol_window.h
@@ -34,9 +34,9 @@ public:
 	}
 
 	inline void preStartInitialize() override {
-		MH_CreateHook((void*)(globals::gameBase + 0x8a27d0), addJamProtocolHook, (void**)(&addJamProtocolPool_orig));
+		MH_CreateHook((void*)(globals::gameBase + 0x8a27d0), (LPVOID)addJamProtocolHook, (void**)(&addJamProtocolPool_orig));
 		MH_EnableHook((void*)(globals::gameBase + 0x8a27d0));
-		MH_CreateHook((void*)(globals::gameBase + 0xf25ba0), associatePoolHook, (void**)(&associatePool_orig));
+		MH_CreateHook((void*)(globals::gameBase + 0xf25ba0), (LPVOID)associatePoolHook, (void**)(&associatePool_orig));
 		MH_EnableHook((void*)(globals::gameBase + 0xf25ba0));
 	}
 

--- a/Prometheus-Core/UI/windows/loadlist_visualizer.h
+++ b/Prometheus-Core/UI/windows/loadlist_visualizer.h
@@ -243,7 +243,7 @@ class loadlist_visualizer : public window {
 				if (entry) {
 					while (entry) {
 						ClonedResourceLoadEntry* clone_inner = new ClonedResourceLoadEntry;
-						memcpy(clone_inner, entry, sizeof ResourceLoadEntry);
+						memcpy(clone_inner, entry, sizeof(ResourceLoadEntry));
 						if (!clone->lists[i].front)
 							clone->lists[i].front = &clone_inner->loaded_entry;
 						if (prev != nullptr)
@@ -301,7 +301,7 @@ class loadlist_visualizer : public window {
 	}
 
 	inline void preStartInitialize() override {
-		MH_CreateHook((LPVOID)(globals::gameBase + 0x9d2e10), __WorkLoadList_hook, (void**)&__WorkLoadList_orig);
+		MH_CreateHook((LPVOID)(globals::gameBase + 0x9d2e10), (LPVOID)__WorkLoadList_hook, (void**)&__WorkLoadList_orig);
 		MH_EnableHook((LPVOID)(globals::gameBase + 0x9d2e10));
 	}
 	//inline void initialize() override {}

--- a/Prometheus-Core/UI/windows/log_window.h
+++ b/Prometheus-Core/UI/windows/log_window.h
@@ -73,7 +73,7 @@ class log_window : public window {
 	}
 
 	inline void preStartInitialize() override {
-		MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x7e5c90), log_fn, (PVOID*)&log_orig_fn));
+		MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x7e5c90), (LPVOID)log_fn, (PVOID*)&log_orig_fn));
 		MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0x7e5c90)));
 	}
 	//inline void initialize() override {}

--- a/Prometheus-Core/UI/windows/movementsys_editor.h
+++ b/Prometheus-Core/UI/windows/movementsys_editor.h
@@ -41,6 +41,7 @@ class movementsys_editor : public window {
 		_orig_list = new movement_vt**[_orig_cnt = ea->movement_systems.num];
 		memcpy(_orig_list, ea->movement_systems.begin(), sizeof(movement_vt**) * ea->movement_systems.num);
 	}
+
 private:
 	struct movsys_state {
 		__int64 vfptr;
@@ -48,13 +49,13 @@ private:
 		bool enabled = true;
 	};
 	static inline std::vector<movsys_state> s_mov_vtables = {
-		{ 0x15c17b0, "stuprojectile" },
-		{ 0x15c1c30, "charmover" },
-		{ 0x15c1ed8, "unsynchronized_mover" },
-		{ 0x15c1ef8, "stuweapon" },
-		{ 0x15c2d90, "statescript" },
-		{ 0x15c4da0, "simplemover" },
-		{ 0x15c4e28, "localplayer" }
+		{ 0x15c17b0, "stuprojectile", true },
+		{ 0x15c1c30, "charmover", true },
+		{ 0x15c1ed8, "unsynchronized_mover", true },
+		{ 0x15c1ef8, "stuweapon", true },
+		{ 0x15c2d90, "statescript", true },
+		{ 0x15c4da0, "simplemover", true },
+		{ 0x15c4e28, "localplayer", true }
 	};
 	movement_vt*** _orig_list;
 	int _orig_cnt;

--- a/Prometheus-Core/Utility/Modules.h
+++ b/Prometheus-Core/Utility/Modules.h
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <string>
+#include <windows.h>
 #include <tlhelp32.h>
 
 #include "idadefs.h"

--- a/Prometheus-Core/dllmain.cpp
+++ b/Prometheus-Core/dllmain.cpp
@@ -407,7 +407,7 @@ __int64 __fastcall createwindow_hook(__int64 gameManager) {
             render = *(DWORD_PTR*)(render + 0x40);
             if (!render)
                 continue;
-            MH_VERIFY(MH_CreateHook((DWORD_PTR*)render, PresentHook, reinterpret_cast<void**>(&phookD3D11Present)));
+            MH_VERIFY(MH_CreateHook((DWORD_PTR*)render, (LPVOID)PresentHook, reinterpret_cast<void**>(&phookD3D11Present)));
             MH_VERIFY(MH_EnableHook((DWORD_PTR*)render));
             return;
         }
@@ -841,41 +841,41 @@ void __cdecl StartHook(void*) {
     printf("patched debugger trap 1 (illegal isntruction)\n");
 
     //ud2
-    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x5abd00), DebuggerTrapHook, 0));
+    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x5abd00), (LPVOID)DebuggerTrapHook, 0));
     MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0x5abd00)));
     //basically same debugger trap here but __debugbreak()
-    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x5abd30), DebuggerTrapHook, 0));
+    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x5abd30), (LPVOID)DebuggerTrapHook, 0));
     MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0x5abd30)));
     //ame but ud2 again
-    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x808b90), DebuggerTrapHook, 0));
+    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x808b90), (LPVOID)DebuggerTrapHook, 0));
     MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0x808b90)));
     //ud2
-    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x7e1710), DebuggerTrapHook, 0));
+    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x7e1710), (LPVOID)DebuggerTrapHook, 0));
     MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0x7e1710)));
     //crash_me__
-    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x1130960), DebuggerTrapHook, 0));
+    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x1130960), (LPVOID)DebuggerTrapHook, 0));
     MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0x1130960)));
 
-    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x8fc240), createwindow_hook, (PVOID*)&createwindow_orig));
+    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x8fc240), (LPVOID)createwindow_hook, (PVOID*)&createwindow_orig));
     MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0x8fc240)));
 
     unsigned char return_zero[] = { 0x31, 0xC0, 0xC3 };
     memcpy((void*)(globals::gameBase + 0x804740), return_zero, sizeof(return_zero));
     printf("patched debugger trap 2 (return value check)\n");
 
-    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x5ac130), regedit_initialize, (PVOID*)&regedit_initialize_orig));
+    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x5ac130), (LPVOID)regedit_initialize, (PVOID*)&regedit_initialize_orig));
     MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0x5ac130)));
     printf("patched regedit launch options\n");
 
-    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x80f7c0), emplace_entity_hook, (PVOID*)&emplace_entity_orig));
+    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x80f7c0), (LPVOID)emplace_entity_hook, (PVOID*)&emplace_entity_orig));
     MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0x80f7c0)));
     printf("emplace entity hook\n");
 
-    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xf3eb10), afterdatapackload_hook, (PVOID*)&afterdatapackload_fn));
+    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xf3eb10), (LPVOID)afterdatapackload_hook, (PVOID*)&afterdatapackload_fn));
     MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0xf3eb10)));
     printf("after data pack load hook\n");
 
-    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xa00450), componen1_oncreate_hook, (PVOID*)&component_1_oncreate_orig));
+    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xa00450), (LPVOID)componen1_oncreate_hook, (PVOID*)&component_1_oncreate_orig));
     MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0xa00450)));
 
     /*MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xbff460), testVIGSTickHook, (PVOID*)&VigsTickOrig));
@@ -1066,25 +1066,25 @@ void __cdecl StartHook(void*) {
     printf("patched veh set trap\n");
 
     printf("casc log hook\n");
-    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xba00e0), cascLogHook, (LPVOID*)&cascLogHook_orig));
+    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xba00e0), (LPVOID)cascLogHook, (LPVOID*)&cascLogHook_orig));
     MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0xba00e0)));
 
-    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xf4dff0), statescript_load_hook, (LPVOID*)&statescript_load_orig));
+    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xf4dff0), (LPVOID)statescript_load_hook, (LPVOID*)&statescript_load_orig));
     MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0xf4dff0)));
 
-    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xb2ae70), stuux_string_hash_hook, (LPVOID*)&stuux_string_hash_orig));
+    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xb2ae70), (LPVOID)stuux_string_hash_hook, (LPVOID*)&stuux_string_hash_orig));
     MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0xb2ae70)));
     printf("stuux string hash uxlink\n");
 
-    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x9c3500), manager_14_init_hook, (LPVOID*)&manager_14_orig));
+    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x9c3500), (LPVOID)manager_14_init_hook, (LPVOID*)&manager_14_orig));
     MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0x9c3500)));
     printf("Manager 14 initialization hook\n");
 
-    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xcd0590), dataflow_bugfix_fn, (LPVOID*)&dataflow_bugfix_orig));
+    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xcd0590), (LPVOID)dataflow_bugfix_fn, (LPVOID*)&dataflow_bugfix_orig));
     MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0xcd0590)));
     printf("filterbits dataflow fix\n");
 
-    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xc541c0), Construct_GameEntityAdmin_fn, (LPVOID*)&Construct_GameEntityAdmin_orig));
+    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xc541c0), (LPVOID)Construct_GameEntityAdmin_fn, (LPVOID*)&Construct_GameEntityAdmin_orig));
     MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0xc541c0)));
     printf("gameEA initialize hook\n");
 
@@ -1098,11 +1098,11 @@ void __cdecl StartHook(void*) {
     memset((void*)(globals::gameBase + 0xcc6110), 0x90, 0xcc67f5 - 0xcc6110);
     memset((void*)(globals::gameBase + 0xcc57d3), 0x90, 0xcc5f92 - 0xcc57d3);
 
-    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xc43a40), selectiveResLoad_hook, (PVOID*)&selectiveResLoad_orig));
+    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xc43a40), (LPVOID)selectiveResLoad_hook, (PVOID*)&selectiveResLoad_orig));
     MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0xc43a40)));
     printf("selectiveResLoad_hook\n");
 
-    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xc43ab0), System63_hook, (PVOID*)&System63_orig));
+    MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xc43ab0), (LPVOID)System63_hook, (PVOID*)&System63_orig));
     MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0xc43ab0)));
     printf("system63 bugfix\n"); 
 
@@ -1199,18 +1199,18 @@ BOOL APIENTRY DllMain(HMODULE hModule,
 
                 MH_VERIFY(MH_Initialize());
 
-                MH_VERIFY(MH_CreateHook(ExitProcess, ExitProcessHook, (LPVOID*)&ExitProcess_orig));
-                MH_VERIFY(MH_EnableHook(ExitProcess));
+                MH_VERIFY(MH_CreateHook((LPVOID)ExitProcess, (LPVOID)ExitProcessHook, (LPVOID*)&ExitProcess_orig));
+                MH_VERIFY(MH_EnableHook((LPVOID)ExitProcess));
 
                 auto addVeh = GetProcAddress(LoadLibraryA("ntdll.dll"), "RtlAddVectoredExceptionHandler");
-                MH_VERIFY(MH_CreateHook(addVeh, AddVehHook, (LPVOID*)&AddVeh_orig));
-                MH_VERIFY(MH_EnableHook(addVeh));
+                MH_VERIFY(MH_CreateHook((LPVOID)addVeh, (LPVOID)AddVehHook, (LPVOID*)&AddVeh_orig));
+                MH_VERIFY(MH_EnableHook((LPVOID)addVeh));
 
-                MH_VERIFY(MH_CreateHook(IsDebuggerPresent, CheckDebuggerPresentHook, 0));
-                MH_VERIFY(MH_EnableHook(IsDebuggerPresent));
+                MH_VERIFY(MH_CreateHook((LPVOID)IsDebuggerPresent, (LPVOID)CheckDebuggerPresentHook, 0));
+                MH_VERIFY(MH_EnableHook((LPVOID)IsDebuggerPresent));
 
-                MH_VERIFY(MH_CreateHook(CheckRemoteDebuggerPresent, CheckDebuggerPresentHook, 0));
-                MH_VERIFY(MH_EnableHook(CheckRemoteDebuggerPresent));
+                MH_VERIFY(MH_CreateHook((LPVOID)CheckRemoteDebuggerPresent, (LPVOID)CheckDebuggerPresentHook, 0));
+                MH_VERIFY(MH_EnableHook((LPVOID)CheckRemoteDebuggerPresent));
 
                 printf("Creating WinMain Hook...\n");
                 unsigned char starthook[] = {

--- a/Prometheus-Core/entity_admin.cpp
+++ b/Prometheus-Core/entity_admin.cpp
@@ -700,19 +700,19 @@ void PrometheusSystem::OnTick(float tick) {
 		if (!_applied_demo) {
 			_applied_demo = true;
 
-			MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x8537c0), get_displayString_func, (PVOID*)&get_displayString_orig));
+			MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x8537c0), (LPVOID)get_displayString_func, (PVOID*)&get_displayString_orig));
 			MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0x8537c0)));
 
-			MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xc87220), play_game_btn, (PVOID*)0));
+			MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xc87220), (LPVOID)play_game_btn, (PVOID*)0));
 			MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0xc87220)));
 
-			MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xd774b0), SendHeroSelection, (PVOID*)0));
+			MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xd774b0), (LPVOID)SendHeroSelection, (PVOID*)0));
 			MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0xd774b0)));
 
-			MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xd94930), matchmaking_cv, (PVOID*)0));
+			MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xd94930), (LPVOID)matchmaking_cv, (PVOID*)0));
 			MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0xd94930)));
 
-			MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xc45400), hookSwitchCam, (PVOID*)&origSwitchCam));
+			MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xc45400), (LPVOID)hookSwitchCam, (PVOID*)&origSwitchCam));
 			MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0xc45400)));
 
 			auto lobby_ss = LobbyEntityAdmin()->getSingletonComponent<Component_23_Statescript>(0x23);
@@ -1212,7 +1212,7 @@ PrometheusSystem* PrometheusSystem::create(EntityAdminBase* ea) {
 	ea->GameEA_mapfunc_arr.emplace_item((mapsystem_callback_vt**)&sys->_mapfunc);
 	s_instance = sys;
 
-	MH_VERIFY_RET(MH_CreateHook((PVOID)(globals::gameBase + 0xcfe920), deallocate_view_hook, (LPVOID*)&deallocate_view_orig), nullptr);
+	MH_VERIFY_RET(MH_CreateHook((PVOID)(globals::gameBase + 0xcfe920), (LPVOID)deallocate_view_hook, (LPVOID*)&deallocate_view_orig), nullptr);
 	MH_VERIFY_RET(MH_EnableHook((PVOID)(globals::gameBase + 0xcfe920)), nullptr);
 	return sys;
 }

--- a/Prometheus-Core/statescript_logger.h
+++ b/Prometheus-Core/statescript_logger.h
@@ -21,22 +21,22 @@ public:
     };
 
     static void Initialize() {
-        MH_CreateHook((PVOID)(globals::gameBase + 0xf4f600), TickScript, (PVOID*)&TickScript_orig);
+        MH_CreateHook((PVOID)(globals::gameBase + 0xf4f600), (LPVOID)TickScript, (PVOID*)&TickScript_orig);
         MH_EnableHook((PVOID)(globals::gameBase + 0xf4f600));
 
-        MH_CreateHook((PVOID)(globals::gameBase + 0xd146a0), OnNodeStateEntry, (PVOID*)&StateEntry_orig);
+        MH_CreateHook((PVOID)(globals::gameBase + 0xd146a0), (LPVOID)OnNodeStateEntry, (PVOID*)&StateEntry_orig);
         MH_EnableHook((PVOID)(globals::gameBase + 0xd146a0));
 
-        MH_CreateHook((PVOID)(globals::gameBase + 0xd14850), OnNodeStateFinished, (PVOID*)&StateFinish_orig);
+        MH_CreateHook((PVOID)(globals::gameBase + 0xd14850), (LPVOID)OnNodeStateFinished, (PVOID*)&StateFinish_orig);
         MH_EnableHook((PVOID)(globals::gameBase + 0xd14850));
 
-        MH_CreateHook((PVOID)(globals::gameBase + 0xd14a20), OnNodeActionEntry, (PVOID*)&ActionEntry_orig);
+        MH_CreateHook((PVOID)(globals::gameBase + 0xd14a20), (LPVOID)OnNodeActionEntry, (PVOID*)&ActionEntry_orig);
         MH_EnableHook((PVOID)(globals::gameBase + 0xd14a20));
 
-        MH_CreateHook((PVOID)(globals::gameBase + 0xf47800), OnScriptEntry, (PVOID*)&ScriptEntry_orig);
+        MH_CreateHook((PVOID)(globals::gameBase + 0xf47800), (LPVOID)OnScriptEntry, (PVOID*)&ScriptEntry_orig);
         MH_EnableHook((PVOID)(globals::gameBase + 0xf47800));
 
-        MH_CreateHook((PVOID)(globals::gameBase + 0xd73a80), Deallocate, (PVOID*)&Deallocate_orig);
+        MH_CreateHook((PVOID)(globals::gameBase + 0xd73a80), (LPVOID)Deallocate, (PVOID*)&Deallocate_orig);
         MH_EnableHook((PVOID)(globals::gameBase + 0xd73a80));
     }
 

--- a/Prometheus-Core/stu_resources.h
+++ b/Prometheus-Core/stu_resources.h
@@ -7,13 +7,13 @@
 class stu_resources {
 public:
 	static inline void initialize() {
-		MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xa4c3f0), STUD_ConstructFromResource, (PVOID*)&stud_construct_orig));
+		MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xa4c3f0), (LPVOID)STUD_ConstructFromResource, (PVOID*)&stud_construct_orig));
 		MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0xa4c3f0)));
 
-		MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xa4c620), STUD_DestroyResource, (PVOID*)&stud_destroy_orig));
+		MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0xa4c620), (LPVOID)STUD_DestroyResource, (PVOID*)&stud_destroy_orig));
 		MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0xa4c620)));
 
-		MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x8553f0), DisplayText_ConstructFromResource, (PVOID*)&DisplayText_construct_orig));
+		MH_VERIFY(MH_CreateHook((PVOID)(globals::gameBase + 0x8553f0), (LPVOID)DisplayText_ConstructFromResource, (PVOID*)&DisplayText_construct_orig));
 		MH_VERIFY(MH_EnableHook((PVOID)(globals::gameBase + 0x8553f0)));
 		memset((void*)(globals::gameBase + 0x8553fb), 0x90, 0x3BB);
 	}


### PR DESCRIPTION
Because of this branch having cmake and all, I did a small addition with minimal refactoring to the code to make LLVM MinGW possible. This has currently been tested under CLion with the MinGW template, with "Toolset" pointing to a LLVM MinGW toolset, gotten from here https://github.com/mstorsjo/llvm-mingw
This is for the UCRT version of it, as MSVCRT is considered "legacy". GCC is not planned as that would require more invasive refactoring even with `-fms-extensions` set.